### PR TITLE
Remove redundant jquery.iframe-transport

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery-fileupload/vendor/jquery.ui.widget
-//= require jquery-fileupload/jquery.iframe-transport
 //= require jquery-fileupload/jquery.fileupload
 //= require bootstrap
 //= require_self


### PR DESCRIPTION
`jquery.iframe-transport` is not needed anymore as [XHR file uploads support](https://caniuse.com/#feat=xhr2) is pretty wide by now. See https://github.com/janko-m/shrine/pull/210 for details.