### PR TITLE
Only allow one file selection for 'cover' non-multiple input

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@ function fileUpload(fileInput) {
       autoProceed: true,
       restrictions: {
         allowedFileTypes: fileInput.accept.split(','),
+        maxNumberOfFiles: (fileInput.multiple ? undefined : 1),
       }
     })
     .use(Uppy.FileInput, {


### PR DESCRIPTION
The "cover" photo only accepts one file, but was resulting in a file open dialog that let you pick multiple files -- all but the first would be ignored by subsequent JS code.

This now demonstrates how to tell uppy to (tell the OS file selection dialog to) only allow one file selection.

Since we're just using the html "multiple" attribute, I'm not sure why uppy doesn't do this already as a default, it could conceivably be a feature PR to uppy. But in the meantime, why not have the demo be more solid and take care of this. Without this change, the demo lets me choose more than one file for 'cover' but they are all ignored; with this change, the demo file open dialog for 'cover' only lets me choose one file. (MacOS Chrome).