### PR TITLE
Support S3 multipart upload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'dotenv-rails'
 
 # Shrine
 gem 'shrine', '~> 2.19.0'
+gem "uppy-s3_multipart", ">= 0.3.2"
 gem 'aws-sdk-s3', '~> 1.14'
 gem 'image_processing', '~> 1.0'
 gem 'marcel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    roda (3.22.0)
+      rack
     ruby-vips (2.0.11)
       ffi (~> 1.9)
     sass (3.5.1)
@@ -178,6 +180,10 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    uppy-s3_multipart (0.3.2)
+      aws-sdk-s3 (~> 1.0)
+      content_disposition (~> 1.0)
+      roda (>= 2.27, < 4)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -206,6 +212,7 @@ DEPENDENCIES
   sqlite3
   sucker_punch (~> 2.0)
   uglifier (>= 1.3.0)
+  uppy-s3_multipart (>= 0.3.2)
   web-console (>= 3.3.0)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ and the web workers aren't blocked by processing, storing or deleting.
 
 ## Implementation
 
-In production environment files are uploaded directly to S3, while in
-development and test environment they are uploaded to the app and stored on
-disk. The demo features both single and multiple uploads.
+The demo can upload files directly to S3 (default in production), or they can be
+uploaded to the app on stored on disk (default in development and test environment).
+See "Upload server modes" below for more info.
+
+The demo features both single and multiple uploads.
 
 On the client side [Uppy] is used for handling file uploads. The complete
 JavaScript implementation for the demo can be found in
@@ -74,6 +76,57 @@ Once you have all of these things set up, you can run the app:
 $ rails server
 ```
 
+## Upload server modes
+
+This demo app is capable of uploading files directly to S3 (using straight upload or S3 multi-part
+upload), or of uploading to an application action and storing on local disk.
+
+In all three modes, the file selected in the browser is immediately uploaded by Javascript to some storage location ("JS direct upload"), and then on form submit a shrine-compatible hash describing the already-stored file is sent to the Rails app. Using shrine [cached_attachment_data](https://github.com/shrinerb/shrine/blob/master/doc/plugins/cached_attachment_data.md) and [restore_cached_data plugins](https://github.com/shrinerb/shrine/blob/master/doc/plugins/restore_cached_data.md). The difference is in where the Javascript sends the file, and how.
+
+You can choose which upload server mode to by setting the `UPLOAD_SERVER` env variable. Otherwise, the default is `s3` in production, and `app` in test and development.
+
+* `s3`
+  * Shrine storages are set to S3.
+  * The [Uppy AwsS3 plugin](https://uppy.io/docs/aws-s3/) is used to upload files directly to the S3 `cache` storage
+  * The shrine [presign_endpoint](https://github.com/shrinerb/shrine/blob/master/doc/plugins/presign_endpoint.md) plugin is used to support Uppy AwsS3 plugin, providing authorized signed
+  S3 URL for upload.
+  * This is the default in Rails `production` environment.
+* `app`
+  * Shrine storages are set to local filesystem, in `./public`.
+  * The Uppy [XHRUpload](https://uppy.io/docs/xhr-upload/) plugin is used to submit files directly to Rails app.
+  * The Shrine [upload_endpoint](https://github.com/shrinerb/shrine/blob/master/doc/plugins/upload_endpoint.md) plugin is used to provide a local app HTTP action to accept the uploads.
+  * This is the default in non-production Rails environments (development and test).
+* `s3_multipart`
+  * Shrine storages are set to S3.
+  * The Uppy [AwsS3Multipart](https://uppy.io/docs/aws-s3-multipart/) plugin is used to upload files directly to the S3 `cache` storage, using S3's multipart upload strategy. This allows files larger than 5GB to be uploaded to S3, and can have other reliability and performance advantages from uploading in multiple smaller requests, especially for large files even if less than 5GB.
+  * The [uppy-s3_multipart](https://github.com/janko/uppy-s3_multipart) gem, supporting the shrine `uppy_s3_multipart` plugin, are used to provide endpoints for the aws-s3-multipart Uppy plugin.
+  * This is never the default, but you can have the app use it by setting an ENV variable.
+
+So if you would like to use the app with the s3_multipart upload server strategy, add `UPLOAD_SERVER=s3_multipart` to your `.env` file, or launch the rails app with:
+
+    UPLOAD_SERVER=s3_multipart rails server
+
+## Consider access control
+
+In a real apps, if you only want logged-in users to be able to upload files directly to your cache storage, you will want to limit access to the signing and/or file-receiving endpoints in routes.rb. For example, if using devise one way to do this is:
+
+  ```rb
+  authenticate :user do
+    mount Shrine.upload_endpoint(:cache) => "/upload"
+  end
+  ```
+
+
+## References
+
 [Shrine]: https://github.com/shrinerb/shrine
+  * Shrine docs: [Direct Uploads to S3](https://shrinerb.com/rdoc/files/doc/direct_s3_md.html)
+  * Shrine wiki: [Adding Direct App Uploads](https://github.com/shrinerb/shrine/wiki/Adding-Direct-App-Uploads)
+  * Shrine wiki: [Adding Direct S3 Uploads](https://github.com/shrinerb/shrine/wiki/Adding-Direct-S3-Uploads)
+  * [uppy-s3_multipart gem](https://github.com/janko/uppy-s3_multipart)
+  * Janko's Blog: [Better File Uploads with Shrine: Direct Uploads](https://twin.github.io/better-file-uploads-with-shrine-direct-uploads/)
+
 [setup CORS]: http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html
 [Uppy]: https://uppy.io
+
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,5 @@
 module ApplicationHelper
   def upload_server
-    if Rails.env.production?
-      :s3
-    else
-      :app
-    end
+    Rails.configuration.upload_server
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,15 @@ module ShrineRailsExample
 
     config.active_record.sqlite3.represent_boolean_as_integer = true
 
+    # supports :s3, :s3_multipart, or :app
+    config.upload_server = if ENV["UPLOAD_SERVER"].present?
+      ENV["UPLOAD_SERVER"].to_sym
+    elsif Rails.env.production?
+      :s3
+    else
+      :app
+    end
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,13 @@ Rails.application.routes.draw do
 
   resources :albums
 
-  if Rails.env.production?
+
+  if Rails.configuration.upload_server == :s3
+    # By default in production we use s3, including upload directly to S3 with
+    # signed url.
     mount Shrine.presign_endpoint(:cache) => "/s3/params"
-  else
-    # In development and test environment we're using filesystem storage
+  else # :app
+    # In development and test environment by default we're using filesystem storage
     # for speed, so on the client side we'll upload files to our app.
     mount Shrine.upload_endpoint(:cache) => "/upload"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
     # By default in production we use s3, including upload directly to S3 with
     # signed url.
     mount Shrine.presign_endpoint(:cache) => "/s3/params"
+  elsif Rails.configuration.upload_server == :s3_multipart
+    # Still upload directly to S3, but using Uppy's AwsS3Multipart plugin
+    mount Shrine.uppy_s3_multipart(:cache) => "/s3"
   else # :app
     # In development and test environment by default we're using filesystem storage
     # for speed, so on the client side we'll upload files to our app.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,6 +1,6 @@
 shared:
-  s3_access_key_id:     <%= ENV.fetch("S3_ACCESS_KEY_ID") if Rails.env.production? %>
-  s3_secret_access_key: <%= ENV.fetch("S3_SECRET_ACCESS_KEY") if Rails.env.production? %>
-  s3_region:            <%= ENV.fetch("S3_REGION") if Rails.env.production? %>
-  s3_bucket:            <%= ENV.fetch("S3_BUCKET") if Rails.env.production? %>
+  s3_access_key_id:     <%= ENV.fetch("S3_ACCESS_KEY_ID") if [:s3, :s3_multipart].include?(Rails.configuration.upload_server) %>
+  s3_secret_access_key: <%= ENV.fetch("S3_SECRET_ACCESS_KEY") if [:s3, :s3_multipart].include?(Rails.configuration.upload_server) %>
+  s3_region:            <%= ENV.fetch("S3_REGION") if [:s3, :s3_multipart].include?(Rails.configuration.upload_server) %>
+  s3_bucket:            <%= ENV.fetch("S3_BUCKET") if [:s3, :s3_multipart].include?(Rails.configuration.upload_server) %>
   secret_key_base: 29aac4f296435c948bbf287456d2214f65f2d9e78285017e9118c113a6b177ae9a990ff5729208b25fceedddca71439bcefd2babc70ee4792938b79192d0647b


### PR DESCRIPTION
* also allow an ENV variable to determine upload server strategy, independently of Rails.env. (Defaults still depend on Rails.env same as they did before)
* also some additional orientation docs in README

@janko I tested s3 multipart and they are working, but I'm not totally sure I'm doing everything 'best practice', appreciate your review.